### PR TITLE
Also build solid-ui in the watch task

### DIFF
--- a/scripts/watch
+++ b/scripts/watch
@@ -5,4 +5,4 @@ npx lerna bootstrap --force-local
 # Concurrently start a `watch` task for solid-ui, solid-panes, and mashlib, and start Node Solid Server.
 # Note that mashlib chokes if the watch task of solid-panes is still starting up while it's running;
 # a hacky workaround to that is to delay it by 20 seconds before starting (`sleep 20`).
-npx concurrently --names "solid-ui,solid-panes,mashlib,node-solid-server" "cd workspaces/solid-ui; #npm run watch" "cd workspaces/solid-panes; npm run watch" "cd workspaces/mashlib; sleep 20; npm run watch" "cd workspaces/node-solid-server; ./bin/solid-test start --root ./data --port 8443 --ssl-key ../privkey.pem --ssl-cert ../fullchain.pem --multiuser"
+npx concurrently --names "solid-ui,solid-panes,mashlib,node-solid-server" "cd workspaces/solid-ui; npm run watch" "cd workspaces/solid-panes; npm run watch" "cd workspaces/mashlib; sleep 20; npm run watch" "cd workspaces/node-solid-server; ./bin/solid-test start --root ./data --port 8443 --ssl-key ../privkey.pem --ssl-cert ../fullchain.pem --multiuser"


### PR DESCRIPTION
The watch task for solid-ui was accidentally left commented-out. Hence https://github.com/inrupt/mashlib-dev/pull/1#issuecomment-522676690

Sorry!